### PR TITLE
add MathJax support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,3 +50,9 @@ about:
   github_username: yanm1ng
   zhihu_username: yummy1121
   douban_username: yanm1ng
+
+# MathJax Support
+mathjax:
+  enable: true
+  per_page: false
+  cdn: //cdn.bootcss.com/mathjax/2.7.1/latest.js?config=TeX-AMS-MML_HTMLorMML

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -23,6 +23,7 @@
   <script src="//cdn.bootcss.com/geopattern/1.2.3/js/geopattern.min.js"></script>
   <script src="//cdn.bootcss.com/nprogress/0.2.0/nprogress.min.js"></script>
   <%- js(['js/qrious', 'js/gitment']) %>
+  <%- partial('_third-party/mathjax') %>
 </head>
 <div class="wechat-share">
   <img src="/css/images/logo.png" />

--- a/layout/_third-party/mathjax.ejs
+++ b/layout/_third-party/mathjax.ejs
@@ -1,0 +1,25 @@
+<% if (theme.mathjax.enable) { %>
+  <% if (!theme.mathjax.per_page || (page.total || page.mathjax)) { %>
+    <!-- MathJax support START -->
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        tex2jax: {
+          inlineMath: [ ['$','$'], ["\\(","\\)"]  ],
+          processEscapes: true,
+          skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+        }
+      });
+    </script>
+
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Queue(function() {
+        var all = MathJax.Hub.getAllJax(), i;
+        for (i=0; i < all.length; i += 1) {
+          all[i].SourceElement().parentNode.className += ' has-jax';
+        }
+      });
+    </script>
+    <script type="text/javascript" src="<%- theme.mathjax.cdn %>"></script>
+    <!-- MathJax support END -->
+  <% } %>
+<% } %>


### PR DESCRIPTION
add MathJax support for theme vexo

给vexo主题添加了MathJax的支持，方便数学公式的编辑
可以在配置文件中开启或关闭，也可以自行设定cdn的地址，还可以在每一篇post的front matter通过mathjax:true/false 来设定是否加载