### PR TITLE
修复代码注释高亮bug

### DIFF
--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -30,6 +30,7 @@
       if (hasLine === 'false') {
         figure.find('.gutter').hide();
       }
+      hljs.configure({useBR: true});
       var lang = figure.attr('class').split(' ')[1] || 'code';
       var codeHtml = $(this).html();
       var codeTag = document.createElement('code');


### PR DESCRIPTION
You can use any tags instead of <pre><code> to mark up your code. If you don't use a container that preserves line breaks you will need to configure highlight.js to use the <br> tag:

hljs.configure({useBR: true});

document.querySelectorAll('div.code').forEach((block) => {
  hljs.highlightBlock(block);
});